### PR TITLE
Upgrade Osmosis to v29.0.0 and add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,46 @@
+# Ignore system-specific files
+.DS_Store
+Thumbs.db
+
+# Ignore editor and IDE configurations
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Ignore log files
+*.log
+
+# Ignore backup and temporary files
+*~
+*.tmp
+*.bak
+
+# Ignore compiled binaries and executables
+*.exe
+*.out
+*.test
+
+# Ignore dependency directories
+vendor/
+node_modules/
+
+# Ignore build artifacts
+build/
+dist/
+target/
+
+# Ignore OS-specific files
+ehthumbs.db
+Icon?
+Desktop.ini
+
+# Ignore Raspberry Pi specific files (if any)
+*.img
+*.iso
+
+# Ignore sensitive files
+.env
+*.pem
+*.key
+*.crt

--- a/statesync.sh
+++ b/statesync.sh
@@ -65,7 +65,7 @@ install_dependencies() {
 install_go() {
     echo "> installing go..."
     sudo rm -rf /usr/local/go && sudo rm -rf $HOME/.go
-    wget -q -O - $GOLINK | bash && source $HOME/.bashrc
+    wget -q -O - $GOLINK | bash -s -- --version 1.23.4 && source $HOME/.bashrc
 }
 
     #fetch chain-registry
@@ -133,9 +133,8 @@ fetch_cr() {
         #SEEDLIST=${ALTSEEDS}
     fi
 
-        #fix osmo version
     if [[ "$CHAIN" == "osmosis" ]] ; then
-        VERSION="v6.0.0"
+        VERSION="v29.0.0"
     fi  
 
     echo "home dir: $NODE_HOME_DIR"


### PR DESCRIPTION
📝Summary:

- add `.gitignore` file to prevent tracking of unnecessary or sensitive files
- upgrade `Osmosis` binary version to `v29.0.0` based on:
   - Osmosis latest upgrade [proposal 920](https://www.mintscan.io/osmosis/proposals/920)
   - [Polkachu](https://polkachu.com/installation/osmosis) Osmosis Node Installation Guide
- upgrade go version to `1.23.4` based on [Polkachu](https://polkachu.com/installation/osmosis) guide and particular go version flag was added based on the [following instructions](https://github.com/canha/golang-tools-install-script?tab=readme-ov-file#package-install-a-custom-go-version)
```
-s -- --version 1.23.4
```